### PR TITLE
Add index commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -383,3 +383,5 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
+# Visual Studio Code
+.vscode/

--- a/GeodeDiscord/Database/ApplicationDbContext.cs
+++ b/GeodeDiscord/Database/ApplicationDbContext.cs
@@ -7,6 +7,7 @@ namespace GeodeDiscord.Database;
 public class ApplicationDbContext : DbContext {
     public DbSet<Quote> quotes { get; set; } = null!;
     public DbSet<StickyRole> stickyRoles { get; set; } = null!;
+    public DbSet<IndexToken> indexTokens { get; set; } = null!;
 
     public string dbPath { get; } = Environment.GetEnvironmentVariable("GEODE_BOT_DB_PATH") ??
         Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GeodeDiscord.db");

--- a/GeodeDiscord/Database/Entities/IndexToken.cs
+++ b/GeodeDiscord/Database/Entities/IndexToken.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace GeodeDiscord.Database.Entities;
+
+[Index(nameof(userId), IsUnique = true)]
+public record IndexToken
+{
+    [Key, DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public required ulong userId { get; init; }
+    public required string indexToken { get; set; }
+}

--- a/GeodeDiscord/Database/Migrations/20250107183427_IndexTokens.Designer.cs
+++ b/GeodeDiscord/Database/Migrations/20250107183427_IndexTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GeodeDiscord.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GeodeDiscord.Database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250107183427_IndexTokens")]
+    partial class IndexTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.8");

--- a/GeodeDiscord/Database/Migrations/20250107183427_IndexTokens.cs
+++ b/GeodeDiscord/Database/Migrations/20250107183427_IndexTokens.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GeodeDiscord.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class IndexTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_stickyRoles",
+                table: "stickyRoles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_stickyRoles_roleId",
+                table: "stickyRoles");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_stickyRoles",
+                table: "stickyRoles",
+                column: "userId");
+
+            migrationBuilder.CreateTable(
+                name: "indexTokens",
+                columns: table => new
+                {
+                    userId = table.Column<ulong>(type: "INTEGER", nullable: false),
+                    indexToken = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_indexTokens", x => x.userId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_stickyRoles_roleId",
+                table: "stickyRoles",
+                column: "roleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_indexTokens_userId",
+                table: "indexTokens",
+                column: "userId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "indexTokens");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_stickyRoles",
+                table: "stickyRoles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_stickyRoles_roleId",
+                table: "stickyRoles");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_stickyRoles",
+                table: "stickyRoles",
+                column: "roleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_stickyRoles_roleId",
+                table: "stickyRoles",
+                column: "roleId",
+                unique: true);
+        }
+    }
+}

--- a/GeodeDiscord/GeodeDiscord.csproj
+++ b/GeodeDiscord/GeodeDiscord.csproj
@@ -20,6 +20,7 @@
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="Serilog" Version="4.0.2" />
       <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/GeodeDiscord/Modules/IndexModule.AdminModule.cs
+++ b/GeodeDiscord/Modules/IndexModule.AdminModule.cs
@@ -1,0 +1,495 @@
+using Discord;
+using Discord.Interactions;
+using JetBrains.Annotations;
+
+using GeodeDiscord.Database;
+using GeodeDiscord.Database.Entities;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using System.Text;
+
+namespace GeodeDiscord.Modules;
+
+public partial class IndexModule {
+    private static string[] UnauthorizedResponses = [
+        "❌ [BUZZER]",
+		"❌ Your princess is in another castle",
+		"❌ Absolutely not",
+		"❌ Get lost",
+		"❌ Sucks to be you",
+		"❌ No admin, laugh at this user",
+		"❌ Admin dashboard",
+		"❌ Why are we here? Just to suffer?",
+		"❌ You hacked the mainframe! Congrats.",
+		"❌ You're an admin, Harry",
+    ];
+
+    [Group("admin", "Administrate the Geode mod index."), UsedImplicitly]
+    public class AdminModule(ApplicationDbContext db) : InteractionModuleBase<SocketInteractionContext> {
+        public async Task<bool> CheckAdmin(HttpClient httpClient, bool respond) {
+            using var response = await httpClient.GetAsync(GetAPIEndpoint("/v1/me"));
+            if (!response.IsSuccessStatusCode) {
+                if (respond) await RespondAsync(
+                    await GetError(response, "An error occurred while checking your admin status"), ephemeral: true);
+                else await ModifyOriginalResponseAsync(async p =>
+                    p.Content = await GetError(response, "An error occurred while checking your admin status"));
+                return false;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var data = JsonConvert.DeserializeObject<JObject>(json);
+            if (data is null || data["payload"] is null || data["payload"]?["admin"] is null) {
+                if (respond) await RespondAsync("❌ An error occurred while parsing your user response.", ephemeral: true);
+                else await ModifyOriginalResponseAsync(p =>
+                    p.Content = "❌ An error occurred while parsing your user response.");
+                return false;
+            }
+
+            if (!data["payload"]?["admin"]?.Value<bool>() ?? false) {
+                if (respond) await RespondAsync(
+                    UnauthorizedResponses[new Random().Next(UnauthorizedResponses.Length)], ephemeral: true);
+                else await ModifyOriginalResponseAsync(p =>
+                    p.Content = UnauthorizedResponses[new Random().Next(UnauthorizedResponses.Length)]);
+                return false;
+            }
+
+            return true;
+        }
+
+        [SlashCommand("verify", "Verify/Unverify a developer on the Geode mod index."), UsedImplicitly]
+        public async Task Verify([Summary(null, "Developer to verify/unverify.")] string developer,
+            [Summary(null, "Verifcation status.")] bool verified) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+
+            if (!await CheckAdmin(httpClient, true)) return;
+
+            using var devResponse = await httpClient.GetAsync(GetAPIEndpoint($"/v1/developers?query={developer}"));
+            if (!devResponse.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(devResponse, "An error occurred while getting the developer data"), ephemeral: true);
+                return;
+            }
+
+            var devJson = await devResponse.Content.ReadAsStringAsync();
+            var devData = JsonConvert.DeserializeObject<JObject>(devJson);
+            if (devData is null || devData["payload"] is null || devData["payload"]?["data"] is null ||
+                devData["payload"]?["data"]?.Count() == 0) {
+                await RespondAsync("❌ An error occurred while parsing the developer response.", ephemeral: true);
+                return;
+            }
+
+            var dev = devData["payload"]?["data"]?[0];
+            if (dev?["verified"]?.Value<bool>() == verified) {
+                await RespondAsync($"❌ Developer is already {(verified ? "" : "un")}verified.", ephemeral: true);
+                return;
+            }
+
+            using var verifyResponse = await httpClient.PutAsync(GetAPIEndpoint($"/v1/developers/{dev?["id"]}"),
+                new StringContent(JsonConvert.SerializeObject(new { verified }), Encoding.UTF8, "application/json"));
+            if (!verifyResponse.IsSuccessStatusCode) {
+                await RespondAsync(
+                    await GetError(verifyResponse, $"An error occurred while {(verified ? "" : "un")}verifying the developer"),
+                    ephemeral: true);
+                return;
+            }
+
+            await RespondAsync($"✅ Successfully {(verified ? "" : "un")}verified developer **" + dev?["display_name"] + "**!");
+        }
+
+        [SlashCommand("update", "Update a mod version's status on the Geode mod index."), UsedImplicitly]
+        public async Task Update([Summary(null, "Mod ID.")] string id, [Summary(null, "Mod version.")] string version,
+            [Summary(null, "New status."), Autocomplete(typeof(StatusAutocompleteHandler))] string status,
+            [Summary(null, "Reason for status change.")] string? reason = null) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+
+            if (!await CheckAdmin(httpClient, true)) return;
+
+            using var response = await httpClient.PutAsync(GetAPIEndpoint($"/v1/mods/{id}/versions/{version}"),
+                new StringContent(JsonConvert.SerializeObject(new { status, info = reason }), Encoding.UTF8, "application/json"));
+
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(
+                    await GetError(response, "An error occurred while updating the mod version status"), ephemeral: true);
+                return;
+            }
+
+            await RespondAsync($"✅ Successfully {status.Replace("ing", "ed")} mod version **{version}**!");
+        }
+
+        public class StatusAutocompleteHandler : AutocompleteHandler {
+            public override Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context,
+                IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services) {
+                IEnumerable<AutocompleteResult> statuses = [
+                    new AutocompleteResult("accepted", "accepted"),
+                    new AutocompleteResult("pending", "pending"),
+                    new AutocompleteResult("rejected", "rejected"),
+                    new AutocompleteResult("unlisted", "unlisted")
+                ];
+
+                return Task.FromResult(AutocompletionResult.FromSuccess(statuses.Take(25)));
+            }
+        }
+
+        [JsonObject]
+        public class GDVersion {
+            [JsonProperty("win")]
+            public string? Windows { get; set; }
+            [JsonProperty("android32")]
+            public string? Android32 { get; set; }
+            [JsonProperty("android64")]
+            public string? Android64 { get; set; }
+            [JsonProperty("mac-intel")]
+            public string? MacIntel { get; set; }
+            [JsonProperty("mac-arm")]
+            public string? MacArm { get; set; }
+        }
+
+        [JsonObject]
+        public class ModDependency {
+            [JsonProperty("mod_id")]
+            public required string ModId { get; set; }
+            [JsonProperty("version")]
+            public required string Version { get; set; }
+            [JsonProperty("importance")]
+            public required string Importance { get; set; }
+        }
+
+        [JsonObject]
+        public class ModDeveloper {
+            [JsonProperty("id")]
+            public required string Id { get; set; }
+            [JsonProperty("username")]
+            public required string Username { get; set; }
+            [JsonProperty("display_name")]
+            public required string DisplayName { get; set; }
+            [JsonProperty("is_owner")]
+            public bool IsOwner { get; set; }
+        }
+
+        [JsonObject]
+        public class ModVersion {
+            [JsonProperty("version")]
+            public required string Version { get; set; }
+            [JsonProperty("name")]
+            public required string Name { get; set; }
+            [JsonProperty("description")]
+            public required string Description { get; set; }
+            [JsonProperty("direct_download_link")]
+            public required string DirectDownloadLink { get; set; }
+            [JsonProperty("hash")]
+            public required string Hash { get; set; }
+            [JsonProperty("geode")]
+            public required string Geode { get; set; }
+            [JsonProperty("gd")]
+            public required GDVersion GD { get; set; }
+            [JsonProperty("early_load")]
+            public bool EarlyLoad { get; set; }
+            [JsonProperty("api")]
+            public bool API { get; set; }
+            [JsonProperty("dependencies")]
+            public required List<ModDependency> Dependencies { get; set; }
+            [JsonProperty("incompatibilities")]
+            public required List<ModDependency> Incompatibilities { get; set; }
+        }
+
+        [JsonObject]
+        public class ModLinks {
+            [JsonProperty("source")]
+            public string? Source { get; set; }
+            [JsonProperty("community")]
+            public string? Community { get; set; }
+            [JsonProperty("homepage")]
+            public string? Homepage { get; set; }
+        }
+
+        [JsonObject]
+        public class Mod {
+            [JsonProperty("id")]
+            public required string Id { get; set; }
+            [JsonProperty("repository")]
+            public string? Repository { get; set; }
+            [JsonProperty("featured")]
+            public bool Featured { get; set; }
+            [JsonProperty("developers")]
+            public required List<ModDeveloper> Developers { get; set; }
+            [JsonProperty("tags")]
+            public required List<string> Tags { get; set; }
+            [JsonProperty("links")]
+            public ModLinks? Links { get; set; }
+        }
+
+        [SlashCommand("pending", "List pending mods on the Geode mod index."), UsedImplicitly]
+        public async Task Pending() {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+
+            if (!await CheckAdmin(httpClient, true)) return;
+
+            await GetPage(1, indexToken, httpClient, true);
+        }
+
+        public async Task GetPage(int page, IndexToken? indexToken, HttpClient? httpClient, bool initial) {
+            indexToken ??= await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) return;
+
+            httpClient ??= new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.GetAsync(GetAPIEndpoint($"/v1/mods?status=pending&page={page}&per_page=1"));
+            if (!response.IsSuccessStatusCode) {
+                if (initial) await RespondAsync(
+                    await GetError(response, "An error occurred while getting the pending mods"), ephemeral: true);
+                else await ModifyOriginalResponseAsync(async p =>
+                    p.Content = await GetError(response, "An error occurred while getting the pending mods"));
+                return;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var data = JsonConvert.DeserializeObject<JObject>(json);
+            if (data is null || data["payload"] is null || data["payload"]?["data"] is null) {
+                if (initial) await RespondAsync("❌ An error occurred while parsing the pending mods response.", ephemeral: true);
+                else await ModifyOriginalResponseAsync(p =>
+                    p.Content = "❌ An error occurred while parsing the pending mods response.");
+                return;
+            }
+
+            if (data["payload"]?["data"]?.Count() == 0) {
+                if (page > 1) await GetPage(page - 1, indexToken, httpClient, initial);
+                else if (initial) await RespondAsync("❌ No pending mods.", ephemeral: true);
+                else await ModifyOriginalResponseAsync(p => p.Content = "❌ No pending mods.");
+                return;
+            }
+
+            var mod = data["payload"]?["data"]?[0]?.ToObject<Mod>();
+
+            using var versionResponse = await httpClient.GetAsync(
+                GetAPIEndpoint($"/v1/mods/{mod?.Id}/versions/{data["payload"]?["data"]?[0]?["versions"]?[0]?["version"]}"));
+            if (!versionResponse.IsSuccessStatusCode) {
+                if (initial) await RespondAsync(
+                    await GetError(versionResponse, "An error occurred while getting the pending mod version"), ephemeral: true);
+                else await ModifyOriginalResponseAsync(async p =>
+                    p.Content = await GetError(versionResponse, "An error occurred while getting the pending mod version"));
+                return;
+            }
+
+            var versionJson = await versionResponse.Content.ReadAsStringAsync();
+            var versionData = JsonConvert.DeserializeObject<JObject>(versionJson);
+            if (versionData is null || versionData["payload"] is null) {
+                if (initial) await RespondAsync(
+                    "❌ An error occurred while parsing the pending mod version response.", ephemeral: true);
+                else await ModifyOriginalResponseAsync(p =>
+                    p.Content = "❌ An error occurred while parsing the pending mod version response.");
+                return;
+            }
+
+            var version = versionData["payload"]?.ToObject<ModVersion>();
+            if (mod is null || version is null) {
+                if (initial) await RespondAsync("❌ An error occurred while parsing the pending mod data.", ephemeral: true);
+                else await ModifyOriginalResponseAsync(p => p.Content = "❌ An error occurred while parsing the pending mod data.");
+                return;
+            }
+
+            var total = data["payload"]?["count"]?.Value<int>() ?? 1;
+
+            var embed = new EmbedBuilder()
+                .WithTitle(mod.Featured ? "⭐️ " : "" + version.Name)
+                .WithDescription(version.Description)
+                .WithUrl(GetWebsiteEndpoint($"/mods/{mod.Id}?version={version.Version}"))
+                .WithFooter($"Page {page} of {total}")
+                .WithThumbnailUrl(GetAPIEndpoint($"/v1/mods/{mod.Id}/logo"))
+                .AddField("ID", mod.Id, true)
+                .AddField("Version", version.Version, true)
+                .AddField("Geode", version.Geode, true)
+                .AddField("Early Load", version.EarlyLoad ? "Yes" : "No", true)
+                .AddField("API", version.API ? "Yes" : "No", true)
+                .AddField("Developers", string.Join(", ", mod.Developers.Select(d =>
+                    $"[{(d.IsOwner ? "**" : "")}{d.DisplayName}{(d.IsOwner ? "**" : "")}]({GetWebsiteEndpoint(
+                        $"/mods?developer={d.Username}")})")), true)
+                .AddField("Geometry Dash", $"Windows: {version.GD.Windows ?? "N/A"}\n" +
+                    $"Android (32-bit): {version.GD.Android32 ?? "N/A"}\n" +
+                    $"Android (64-bit): {version.GD.Android64 ?? "N/A"}\n" +
+                    $"macOS (Intel): {version.GD.MacIntel ?? "N/A"}\n" +
+                    $"macOS (ARM): {version.GD.MacArm ?? "N/A"}", false)
+                .AddField("Dependencies", version.Dependencies.Count == 0 ? "None" :
+                    $"`{string.Join("`\n`", version.Dependencies.Select(d =>
+                        $"{d.ModId} {d.Version} ({d.Importance})"))}`", false)
+                .AddField("Incompatibilities", version.Incompatibilities.Count == 0 ? "None" :
+                    $"`{string.Join("`\n`", version.Incompatibilities.Select(d =>
+                        $"{d.ModId} {d.Version} ({d.Importance})"))}`", false)
+                .AddField("Source", mod.Links is not null && mod.Links.Source is not null ? mod.Links.Source : mod.Repository ?? "N/A", true)
+                .AddField("Community", mod.Links is not null ? mod.Links.Community ?? "N/A" : "N/A", true)
+                .AddField("Homepage", mod.Links is not null ? mod.Links.Homepage ?? "N/A" : "N/A", true)
+                .AddField("Hash", $"`{version.Hash}`", true)
+                .AddField("Download", version.DirectDownloadLink, true)
+                .AddField("Tags", mod.Tags.Count == 0 ? "None" : $"`{string.Join("`, `", mod.Tags)}`", true);
+
+            var components = new ComponentBuilder()
+                .WithButton("Previous", "index/admin/previous", ButtonStyle.Primary, new Emoji("◀️"))
+                .WithButton("Accept", "index/admin/accept", ButtonStyle.Success, new Emoji("✅"))
+                .WithButton("Reject", "index/admin/reject", ButtonStyle.Danger, new Emoji("❌"))
+                .WithButton("Next", "index/admin/next", ButtonStyle.Primary, new Emoji("▶️"))
+                .WithSelectMenu("index/admin/page", Enumerable.Range(1, total)
+                    .Select(i => new SelectMenuOptionBuilder().WithLabel(i.ToString()).WithValue(i.ToString()))
+                    .ToList(), "Go to page...");
+
+            if (initial) await RespondAsync(embed: embed.Build(), components: components.Build(), ephemeral: true);
+            else await ModifyOriginalResponseAsync(p => {
+                p.Embeds = new[] { embed.Build() };
+                p.Components = components.Build();
+            });
+        }
+
+        [ComponentInteraction("previous"), UsedImplicitly]
+        public async Task Previous() {
+            await DeferAsync(ephemeral: true);
+
+            var message = await GetOriginalResponseAsync();
+
+            var embed = message.Embeds.ElementAt(0);
+            if (embed is null) return;
+
+            var footer = embed.Footer;
+            if (footer is null || !footer.HasValue) return;
+
+            var splitFooter = footer.Value.Text.Split(' ');
+            var page = int.Parse(splitFooter[1]);
+            var count = int.Parse(splitFooter[3]);
+
+            await ModifyOriginalResponseAsync(p => p.Content = "\u200b");
+
+            await GetPage(page > 1 ? page - 1 : count, null, null, false);
+        }
+
+        [ComponentInteraction("next"), UsedImplicitly]
+        public async Task Next() {
+            await DeferAsync(ephemeral: true);
+
+            var message = await GetOriginalResponseAsync();
+
+            var embed = message.Embeds.ElementAt(0);
+            if (embed is null) return;
+
+            var footer = embed.Footer;
+            if (footer is null || !footer.HasValue) return;
+
+            var splitFooter = footer.Value.Text.Split(' ');
+            var page = int.Parse(splitFooter[1]);
+            var count = int.Parse(splitFooter[3]);
+
+            await ModifyOriginalResponseAsync(p => p.Content = "\u200b");
+
+            await GetPage(page < count ? page + 1 : 1, null, null, false);
+        }
+
+        [ComponentInteraction("accept"), UsedImplicitly]
+        public async Task Accept() {
+            var modal = new ModalBuilder()
+                .WithTitle("Accept Mod")
+                .WithCustomId("index/admin/confirm:accepted")
+                .AddTextInput("Reason", "reason", TextInputStyle.Paragraph, "Leave blank for no reason", required: false)
+                .Build();
+
+            await RespondWithModalAsync(modal);
+        }
+
+        [ComponentInteraction("reject"), UsedImplicitly]
+        public async Task Reject() {
+            var modal = new ModalBuilder()
+                .WithTitle("Reject Mod")
+                .WithCustomId("index/admin/confirm:rejected")
+                .AddTextInput("Reason", "reason", TextInputStyle.Paragraph, "Leave blank for no reason", required: false)
+                .Build();
+
+            await RespondWithModalAsync(modal);
+        }
+
+        [ComponentInteraction("page"), UsedImplicitly]
+        public async Task Page(string page) {
+            await DeferAsync(ephemeral: true);
+
+            await ModifyOriginalResponseAsync(p => p.Content = "\u200b");
+
+            await GetPage(int.Parse(page), null, null, false);
+        }
+
+        public class ModStatusModal : IModal {
+            public string Title => string.Empty;
+
+            [ModalTextInput("reason")]
+            public string? Reason { get; set; }
+        }
+
+        [ModalInteraction("confirm:*"), UsedImplicitly]
+        public async Task UpdateModStatus(string status, ModStatusModal modal) {
+            await DeferAsync(ephemeral: true);
+
+            var message = await GetOriginalResponseAsync();
+
+            var embed = message.Embeds.ElementAt(0);
+            if (embed is null) return;
+
+            var name = embed.Title.Contains("⭐️") ? string.Join(' ', embed.Title.Split(' ').Skip(1)) : embed.Title;
+
+            var id = embed.Fields.ToList().Find(f => f.Name == "ID").Value;
+            if (id is null) return;
+
+            var version = embed.Fields.ToList().Find(f => f.Name == "Version").Value;
+            if (version is null) return;
+
+            var footer = embed.Footer;
+            if (footer is null || !footer.HasValue) return;
+
+            var page = int.Parse(footer.Value.Text.Split(' ')[1]);
+
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await ModifyOriginalResponseAsync(p => p.Content = "❌ You must log in to your Geode account first.");
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+
+            if (!await CheckAdmin(httpClient, false)) return;
+
+            using var response = await httpClient.PutAsync(GetAPIEndpoint($"/v1/mods/{id}/versions/{version}"),
+                new StringContent(JsonConvert.SerializeObject(new { status, info = modal.Reason }),
+                Encoding.UTF8, "application/json"));
+            if (!response.IsSuccessStatusCode) {
+                await ModifyOriginalResponseAsync(async p =>
+                    p.Content = await GetError(response, $"An error occurred while {status.Replace("ed", "ing")} the mod"));
+                return;
+            }
+
+            await ModifyOriginalResponseAsync(p =>
+                p.Content = $"✅ Successfully {status.Replace("ing", "ed")} **{name} {version}**!");
+
+            await GetPage(page, indexToken, httpClient, false);
+        }
+    }
+}

--- a/GeodeDiscord/Modules/IndexModule.AdminModule.cs
+++ b/GeodeDiscord/Modules/IndexModule.AdminModule.cs
@@ -15,15 +15,15 @@ namespace GeodeDiscord.Modules;
 public partial class IndexModule {
     private static string[] UnauthorizedResponses = [
         "❌ [BUZZER]",
-		"❌ Your princess is in another castle",
-		"❌ Absolutely not",
-		"❌ Get lost",
-		"❌ Sucks to be you",
-		"❌ No admin, laugh at this user",
-		"❌ Admin dashboard",
-		"❌ Why are we here? Just to suffer?",
-		"❌ You hacked the mainframe! Congrats.",
-		"❌ You're an admin, Harry",
+        "❌ Your princess is in another castle",
+        "❌ Absolutely not",
+        "❌ Get lost",
+        "❌ Sucks to be you",
+        "❌ No admin, laugh at this user",
+        "❌ Admin dashboard",
+        "❌ Why are we here? Just to suffer?",
+        "❌ You hacked the mainframe! Congrats.",
+        "❌ You're an admin, Harry",
     ];
 
     [Group("admin", "Administrate the Geode mod index."), UsedImplicitly]

--- a/GeodeDiscord/Modules/IndexModule.ModsModule.cs
+++ b/GeodeDiscord/Modules/IndexModule.ModsModule.cs
@@ -1,0 +1,312 @@
+using Discord;
+using Discord.Interactions;
+using JetBrains.Annotations;
+
+using GeodeDiscord.Database;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using System.IO.Compression;
+using System.Text;
+
+namespace GeodeDiscord.Modules;
+
+public partial class IndexModule {
+    [Group("mods", "Interact with your mods on the Geode index."), UsedImplicitly]
+    public class ModsModule(ApplicationDbContext db) : InteractionModuleBase<SocketInteractionContext> {
+        [SlashCommand("create", "Create a new mod on the Geode index."), UsedImplicitly]
+        public async Task Create([Summary(null, "Download link to the .geode file.")] string downloadLink) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.PostAsync(GetAPIEndpoint("/v1/mods"),
+                new StringContent(JsonConvert.SerializeObject(new { download_link = downloadLink }),
+                Encoding.UTF8, "application/json"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while creating your mod"), ephemeral: true);
+                return;
+            }
+
+            await RespondAsync("✅ Successfully created your mod!", ephemeral: true);
+        }
+
+        [SlashCommand("update", "Update an existing mod on the Geode index."), UsedImplicitly]
+        public async Task Update([Summary(null, "Download link to the .geode file.")] string downloadLink) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            using var zipResponse = await httpClient.GetAsync(downloadLink);
+            if (!zipResponse.IsSuccessStatusCode) {
+                await RespondAsync("❌ An error occurred while downloading your mod.", ephemeral: true);
+                return;
+            }
+
+            var zipStream = await zipResponse.Content.ReadAsStreamAsync();
+            var zipArchive = new ZipArchive(zipStream);
+            var geodeEntry = zipArchive.GetEntry("mod.json");
+            if (geodeEntry is null) {
+                await RespondAsync("❌ Your mod does not contain a mod.json file.", ephemeral: true);
+                return;
+            }
+
+            var geodeStream = geodeEntry.Open();
+            var geodeReader = new StreamReader(geodeStream);
+            var geodeJson = await geodeReader.ReadToEndAsync();
+            var geodeData = JsonConvert.DeserializeObject<JObject>(geodeJson);
+            if (geodeData is null || geodeData["id"] is null) {
+                await RespondAsync("❌ Your mod.json file is missing the \"id\" field.", ephemeral: true);
+                return;
+            }
+
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.PostAsync(GetAPIEndpoint($"/v1/mods/{geodeData["id"]}/versions"),
+                new StringContent(JsonConvert.SerializeObject(new { download_link = downloadLink }),
+                Encoding.UTF8, "application/json"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while updating your mod"), ephemeral: true);
+                return;
+            }
+
+            await RespondAsync("✅ Successfully updated your mod!", ephemeral: true);
+        }
+
+        [SlashCommand("add-dev", "Add a developer to an existing mod on the Geode index."), UsedImplicitly]
+        public async Task AddDeveloper([Summary(null, "ID of the mod.")] string modId,
+            [Summary(null, "Username of the developer.")] string developer) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.PostAsync(GetAPIEndpoint($"/v1/mods/{modId}/developers"),
+                new StringContent(JsonConvert.SerializeObject(new { username = developer }), Encoding.UTF8, "application/json"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while adding the developer"), ephemeral: true);
+                return;
+            }
+
+            await RespondAsync("✅ Successfully added developer to mod!", ephemeral: true);
+        }
+
+        [SlashCommand("remove-dev", "Remove a developer from an existing mod on the Geode index."), UsedImplicitly]
+        public async Task RemoveDeveloper([Summary(null, "ID of the mod.")] string modId,
+            [Summary(null, "Username of the developer.")] string developer) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.DeleteAsync(GetAPIEndpoint($"/v1/mods/{modId}/developers/{developer}"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while removing the developer"), ephemeral: true);
+                return;
+            }
+
+            await RespondAsync("✅ Successfully removed developer from mod!", ephemeral: true);
+        }
+
+        [JsonObject]
+        public class SimpleModVersion {
+            [JsonProperty("name")]
+            public required string Name { get; set; }
+            [JsonProperty("version")]
+            public required string Version { get; set; }
+        }
+
+        [JsonObject]
+        public class SimpleMod {
+            [JsonProperty("id")]
+            public required string Id { get; set; }
+            [JsonProperty("featured")]
+            public bool Featured { get; set; }
+            [JsonProperty("versions")]
+            public required List<SimpleModVersion> Versions { get; set; }
+        }
+
+        private static readonly Dictionary<ulong, List<SimpleMod>> MessageData = [];
+
+        [SlashCommand("pending", "View your pending mods on the Geode index."), UsedImplicitly]
+        public async Task Pending() {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.GetAsync(GetAPIEndpoint("/v1/me/mods?status=pending"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while getting your pending mods"), ephemeral: true);
+                return;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var data = JsonConvert.DeserializeObject<JObject>(json);
+            if (data is null || data["payload"] is null) {
+                await RespondAsync("❌ An error occurred while parsing your pending mods response.", ephemeral: true);
+                return;
+            }
+
+            if (data["payload"]?.Count() == 0) {
+                await RespondAsync("❌ You have no pending mods!", ephemeral: true);
+                return;
+            }
+
+            var mods = data["payload"]?.ToObject<List<SimpleMod>>();
+            if (mods is null) {
+                await RespondAsync("❌ An error occurred while parsing your pending mods response.", ephemeral: true);
+                return;
+            }
+
+            var component = new ComponentBuilder()
+                .WithButton("Previous", "index/mods/previous:pending", ButtonStyle.Primary, new Emoji("◀️"))
+                .WithButton("Next", "index/mods/next:pending", ButtonStyle.Primary, new Emoji("▶️"))
+                .WithSelectMenu("index/mods/select:pending", mods.Select(mod =>
+                    new SelectMenuOptionBuilder()
+                        .WithLabel(mod.Versions[0].Name)
+                        .WithValue(mods.FindIndex(m => m.Id == mod.Id).ToString())).ToList(), "Select a mod...");
+
+            await RespondAsync(components: component.Build(), ephemeral: true);
+
+            var message = await Context.Interaction.GetOriginalResponseAsync();
+
+            MessageData[message.Id] = mods;
+
+            await GoToPage(0, false);
+        }
+
+        [SlashCommand("published", "View your published mods on the Geode index."), UsedImplicitly]
+        public async Task Published() {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.GetAsync(GetAPIEndpoint("/v1/me/mods?status=accepted"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while getting your published mods"), ephemeral: true);
+                return;
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var data = JsonConvert.DeserializeObject<JObject>(json);
+            if (data is null || data["payload"] is null) {
+                await RespondAsync("❌ An error occurred while parsing your published mods response.", ephemeral: true);
+                return;
+            }
+
+            if (data["payload"]?.Count() == 0) {
+                await RespondAsync("❌ You have no published mods!", ephemeral: true);
+                return;
+            }
+
+            var mods = data["payload"]?.ToObject<List<SimpleMod>>();
+            if (mods is null) {
+                await RespondAsync("❌ An error occurred while parsing your published mods response.", ephemeral: true);
+                return;
+            }
+
+            var component = new ComponentBuilder()
+                .WithButton("Previous", "index/mods/previous:published", ButtonStyle.Primary, new Emoji("◀️"))
+                .WithButton("Next", "index/mods/next:published", ButtonStyle.Primary, new Emoji("▶️"))
+                .WithSelectMenu("index/mods/select:published", mods.Select(mod =>
+                    new SelectMenuOptionBuilder()
+                        .WithLabel(mod.Versions[0].Name)
+                        .WithValue(mods.FindIndex(m => m.Id == mod.Id).ToString())).ToList(), "Select a mod...");
+
+            await RespondAsync(components: component.Build(), ephemeral: true);
+
+            var message = await Context.Interaction.GetOriginalResponseAsync();
+
+            MessageData[message.Id] = mods;
+
+            await GoToPage(0, true);
+        }
+
+        [ComponentInteraction("previous:*"), UsedImplicitly]
+        public async Task PreviousPage(string command) {
+            await DeferAsync(ephemeral: true);
+
+            var message = await Context.Interaction.GetOriginalResponseAsync();
+            if (!MessageData.TryGetValue(message.Id, out List<SimpleMod>? mods)) return;
+
+            var embeds = message.Embeds;
+            if (embeds.Count == 0) return;
+
+            var footer = embeds.ElementAt(0).Footer;
+            if (footer is null) return;
+
+            var page = int.Parse(footer.Value.Text.Split(' ')[1]) - 2;
+            await GoToPage(page >= 0 ? page : mods.Count - 1, command.EndsWith("published"));
+        }
+
+        [ComponentInteraction("next:*"), UsedImplicitly]
+        public async Task NextPage(string command) {
+            await DeferAsync(ephemeral: true);
+
+            var message = await Context.Interaction.GetOriginalResponseAsync();
+            if (!MessageData.TryGetValue(message.Id, out List<SimpleMod>? mods)) return;
+
+            var embeds = message.Embeds;
+            if (embeds.Count == 0) return;
+
+            var footer = embeds.ElementAt(0).Footer;
+            if (footer is null) return;
+
+            var page = int.Parse(footer.Value.Text.Split(' ')[1]);
+            await GoToPage(page < mods.Count ? page : 0, command.EndsWith("published"));
+        }
+
+        [ComponentInteraction("select:*"), UsedImplicitly]
+        public async Task SelectMod(string command, string page) {
+            await DeferAsync(ephemeral: true);
+
+            await GoToPage(int.Parse(page), command.EndsWith("published"));
+        }
+
+        public async Task GoToPage(int page, bool published) {
+            var message = await Context.Interaction.GetOriginalResponseAsync();
+            var mods = MessageData[message.Id];
+            if (mods is null) return;
+
+            var mod = mods[page];
+            if (mod is null) return;
+
+            var embed = new EmbedBuilder()
+                .WithTitle((mod.Featured ? "⭐️ " : "") + mod.Versions[0].Name)
+                .AddField($"{(published ? "Published" : "Pending")} versions",
+                    $"`{string.Join("`, `", mod.Versions.Select(version => version.Version))}`")
+                .WithThumbnailUrl(GetAPIEndpoint($"/v1/mods/{mod.Id}/logo"))
+                .WithFooter($"Page {page + 1} of {mods.Count}")
+                .WithUrl(GetWebsiteEndpoint($"/mods/{mod.Id}"));
+
+            await ModifyOriginalResponseAsync(props => props.Embeds = new[] { embed.Build() });
+        }
+    }
+}

--- a/GeodeDiscord/Modules/IndexModule.ProfileModule.cs
+++ b/GeodeDiscord/Modules/IndexModule.ProfileModule.cs
@@ -1,0 +1,37 @@
+using Discord.Interactions;
+using JetBrains.Annotations;
+
+using GeodeDiscord.Database;
+
+using Newtonsoft.Json;
+
+using System.Text;
+
+namespace GeodeDiscord.Modules;
+
+public partial class IndexModule {
+    [Group("profile", "Interact with your index profile."), UsedImplicitly]
+    public class ProfileModule(ApplicationDbContext db) : InteractionModuleBase<SocketInteractionContext> {
+        [SlashCommand("rename", "Change your Geode display name."), UsedImplicitly]
+        public async Task Rename([Summary(null, "New display name.")] string name) {
+            var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+            if (indexToken is null) {
+                await RespondAsync("❌ You must log in to your Geode account first.", ephemeral: true);
+                return;
+            }
+
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.PutAsync(GetAPIEndpoint("/v1/me"),
+                new StringContent(JsonConvert.SerializeObject(new { display_name = name }), Encoding.UTF8, "application/json"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while updating your display name"), ephemeral: true);
+                return;
+            }
+
+            // get payload.display_name
+            await RespondAsync("✅ Successfully updated your display name to **" + name + "**!", ephemeral: true);
+        }
+    }
+}

--- a/GeodeDiscord/Modules/IndexModule.cs
+++ b/GeodeDiscord/Modules/IndexModule.cs
@@ -1,0 +1,133 @@
+using Discord.Interactions;
+using JetBrains.Annotations;
+
+using GeodeDiscord.Database;
+using GeodeDiscord.Database.Entities;
+
+using Microsoft.EntityFrameworkCore;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GeodeDiscord.Modules;
+
+[Group("index", "Interact with the Geode mod index."), UsedImplicitly]
+public partial class IndexModule(ApplicationDbContext db) : InteractionModuleBase<SocketInteractionContext> {
+    public static string APIEndpoint { get; } = Environment.GetEnvironmentVariable("GEODE_API") ?? "https://api.geode-sdk.org";
+    public static string WebsiteEndpoint { get; } = Environment.GetEnvironmentVariable("GEODE_WEBSITE") ?? "https://geode-sdk.org";
+
+    public static string GetAPIEndpoint(string path) => $"{APIEndpoint}{path}";
+    public static string GetWebsiteEndpoint(string path) => $"{WebsiteEndpoint}{path}";
+
+    public static async Task<string> GetError(HttpResponseMessage response, string message) {
+        if (response.IsSuccessStatusCode) return "";
+
+        var json = await response.Content.ReadAsStringAsync();
+        var data = JsonConvert.DeserializeObject<JObject>(json);
+        if (data is null || data["error"] is null) {
+            return $"❌ {message}.";
+        }
+
+        return $"❌ {message}: `{data["error"]?.Value<string>()}`.";
+    }
+
+    [SlashCommand("login", "Log in to your Geode account."), UsedImplicitly]
+    public async Task Login([Summary(null, "Token to log in with.")] string token) {
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Authorization = new("Bearer", token);
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+        using var response = await httpClient.GetAsync(GetAPIEndpoint("/v1/me"));
+        if (!response.IsSuccessStatusCode) {
+            await RespondAsync(await GetError(response, "An error occurred while logging in"), ephemeral: true);
+            return;
+        }
+
+        var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+        if (indexToken is null) {
+            indexToken = new IndexToken {
+                userId = Context.User.Id,
+                indexToken = token
+            };
+            await db.indexTokens.AddAsync(indexToken);
+        } else {
+            indexToken.indexToken = token;
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        var data = JsonConvert.DeserializeObject<JObject>(json);
+        if (data is null || data["payload"] is null) {
+            await RespondAsync(await GetError(response, "An error occurred while parsing the user response"), ephemeral: true);
+            return;
+        }
+
+        try {
+            await db.SaveChangesAsync();
+            await RespondAsync("✅ Successfully logged in as **" + data["payload"]?["display_name"] + "**!", ephemeral: true);
+        } catch (DbUpdateException) {
+            await RespondAsync("❌ An error occurred while saving your token.", ephemeral: true);
+        }
+    }
+
+    [SlashCommand("logout", "Log out of your Geode account."), UsedImplicitly]
+    public async Task Logout([Summary(null, "Whether to invalidate the token.")] bool invalidate = false) {
+        var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+        if (indexToken is null) {
+            await RespondAsync("❌ You are not logged in.", ephemeral: true);
+            return;
+        }
+
+        db.indexTokens.Remove(indexToken);
+
+        try {
+            await db.SaveChangesAsync();
+            if (!invalidate) {
+                await RespondAsync("✅ Successfully logged out!", ephemeral: true);
+                return;
+            }
+        } catch (DbUpdateException) {
+            await RespondAsync("❌ An error occurred while updating login status.", ephemeral: true);
+            return;
+        }
+
+        if (invalidate) {
+            var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+            using var response = await httpClient.DeleteAsync(GetAPIEndpoint("/v1/me/token"));
+            if (!response.IsSuccessStatusCode) {
+                await RespondAsync(await GetError(response, "An error occurred while invalidating the token"), ephemeral: true);
+                return;
+            }
+
+            await RespondAsync("✅ Successfully logged out and invalidated token!", ephemeral: true);
+        }
+    }
+
+    [SlashCommand("invalidate", "Log out and invalidate all tokens."), UsedImplicitly]
+    public async Task Invalidate() {
+        var indexToken = await db.indexTokens.FindAsync(Context.User.Id);
+        if (indexToken is null) {
+            await RespondAsync("❌ You are not logged in.", ephemeral: true);
+            return;
+        }
+
+        db.indexTokens.Remove(indexToken);
+        try {
+            await db.SaveChangesAsync();
+        } catch (DbUpdateException) {
+            await RespondAsync("❌ An error occurred while updating login status.", ephemeral: true);
+            return;
+        }
+
+        var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Authorization = new("Bearer", indexToken.indexToken);
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "GeodeDiscord");
+        using var response = await httpClient.DeleteAsync(GetAPIEndpoint("/v1/me/tokens"));
+        if (!response.IsSuccessStatusCode) {
+            await RespondAsync(await GetError(response, "An error occurred while invalidating tokens"), ephemeral: true);
+            return;
+        }
+
+        await RespondAsync("✅ Successfully invalidated all tokens!", ephemeral: true);
+    }
+}


### PR DESCRIPTION
For what I added in this pull request:
- /index admin pending (List pending mods)
- /index admin update (Update mod status)
- /index admin verify (Change developer verification status)
- /index invalidate (Log out and invalidate all tokens)
- /index login (Log in with index token)
- /index logout (Log out)
- /index mods add-dev (Add developer to mod)
- /index mods create (Create a new mod)
- /index mods pending (List user pending mods)
- /index mods published (List user published mods)
- /index mods remove-dev (Remove developer from mod)
- /index mods update (Update existing mod)
- /index profile rename (Change display name)

Yeah, it's a mouthful. I know my code sucks, but I haven't programmed in C# since 2023, and I haven't had much experience with Discord bots of this magnitude, so I'm a bit rusty.

If there's anything you want me to change, just let me know in the comments section down below.

Also, if you want a different server, just change the `GEODE_API` environment variable. Just make sure to have the protocol at the start and no trailing slash.